### PR TITLE
Create template for acceptance tests

### DIFF
--- a/.github/ISSUE_TEMPLATE/acceptance_test.md
+++ b/.github/ISSUE_TEMPLATE/acceptance_test.md
@@ -1,0 +1,68 @@
+---
+name: Acceptance test
+about: Create an acceptance test to have a feature approved
+title: ''
+labels: 'Acceptance test'
+assignees: ''
+
+---
+
+**Acceptance test:** 
+
+The indicator for the acceptance test, e.g. AT-1-1
+
+
+
+**Feature:** 
+
+The indicator for the feature, e.g. FT-1-1
+
+
+
+**Feature description:** 
+
+Text description of the feature, e.g. As a user I want to view my current location on campus.
+
+
+
+**Acceptance criteria:**
+
+Steps to perform acceptance test, with each on a different line, e.g.
+
+Given that I have opened the app,
+
+And that I am on the map page,
+
+I could press the current location icon to recenter the map to my current location,
+
+and I should see a double circle icon on the map indicating my current location.
+
+
+
+**Previous evaluation:**
+
+Table documenting the previous times this acceptance test was evaluated, including the outcome, the date, and any comments provided by the product owner, e.g.
+
+Date | Outcome | Comments
+--- | --- | ---
+2020-03-02 | Fail | Recenter to move zoomed in, show proper message when location is not available or not enough permission.
+
+Remove this section if this acceptance test has never been evaluated prior.
+
+
+
+**Result:**
+
+To be filled in by product owner upon evaluation.
+
+
+
+**Date:**
+
+To be filled in by product owner upon evaluation.
+
+
+
+**Signature:**
+
+To be filled in by product owner upon evaluation.


### PR DESCRIPTION
Template for putting acceptance tests on GitHub. We will need to add acceptance tests on GitHub since the product owner meeting on March 23 will be replaced. This template will allow us to consistently make acceptance tests for all features we would like the product owner to review.