### PR TITLE
Def 10 missing location message

### DIFF
--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -2,6 +2,7 @@ package com.soen390.conumap
 
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.view.Gravity
 import android.view.Menu
 import android.widget.Toast
 import androidx.activity.viewModels
@@ -71,11 +72,14 @@ class MainActivity : AppCompatActivity() {
                     Map.centerMapOnUserLocation(this)
                 } else {
                     // User rejected the location permission.
-                    Toast.makeText(
+                    val locationDeniedMessage: Toast = Toast.makeText(
                         applicationContext,
-                        "Please allow location access, otherwise the functionality of the app will be limited.",
+                        "Please allow location access to use all app features.",
                         Toast.LENGTH_LONG
-                    ).show()
+                    )
+                    // Position the toast in the center so it is more likely to be seen by user.
+                    locationDeniedMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
+                    locationDeniedMessage.show()
                 }
                 return
             }

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -11,10 +11,7 @@ import androidx.navigation.ui.setupWithNavController
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.helper.ContextPasser
-import com.soen390.conumap.helper.DeviceLocationChecker
-import com.soen390.conumap.map.Map
 import com.soen390.conumap.permission.Permission
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -3,6 +3,7 @@ package com.soen390.conumap
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.Menu
+import android.widget.Toast
 import androidx.activity.viewModels
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.snackbar.Snackbar
@@ -70,6 +71,11 @@ class MainActivity : AppCompatActivity() {
                     Map.centerMapOnUserLocation(this)
                 } else {
                     // User rejected the location permission.
+                    Toast.makeText(
+                        applicationContext,
+                        "Please allow location access, otherwise the functionality of the app will be limited.",
+                        Toast.LENGTH_LONG
+                    ).show()
                 }
                 return
             }

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -32,7 +32,7 @@ class MainActivity : AppCompatActivity() {
 
         val toolbar: Toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)
-        
+
         val drawerLayout: DrawerLayout = findViewById(R.id.drawer_layout)
         val navView: NavigationView = findViewById(R.id.nav_view)
         val navController = findNavController(R.id.nav_host_fragment)

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -21,9 +21,9 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import com.soen390.conumap.Directions.directions
+import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.databinding.DirectionsFragmentBinding
 import com.soen390.conumap.ui.directions.DirectionsViewModel
-import com.soen390.conumap.building.BuildingCreator.setContext
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.map.Map.LOCATION_PERMISSION_REQUEST_CODE
 
@@ -49,7 +49,8 @@ class MainActivity : AppCompatActivity() {
         navView.setupWithNavController(navController)
 
         // Pass context to these files so they can access the resources.
-        setContext(this)
+        Map.setContext(this)
+        BuildingCreator.setContext(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.soen390.conumap.building.BuildingCreator
+import com.soen390.conumap.helper.ContextPasser
 import com.soen390.conumap.helper.DeviceLocationChecker
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.permission.Permission
@@ -37,11 +38,8 @@ class MainActivity : AppCompatActivity() {
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
 
-        // Pass context to these files so they can access the resources.
-        Map.setContext(this)
-        BuildingCreator.setContext(this)
-        Permission.setContext(this)
-        DeviceLocationChecker.setUp(this)
+        // Pass context to other files that require it.
+        ContextPasser.setContexts(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -32,12 +32,7 @@ class MainActivity : AppCompatActivity() {
 
         val toolbar: Toolbar = findViewById(R.id.toolbar)
         setSupportActionBar(toolbar)
-
-        val fab: FloatingActionButton = findViewById(R.id.fab)
-        fab.setOnClickListener { view ->
-            Snackbar.make(view, "Replace with your own action", Snackbar.LENGTH_LONG)
-                    .setAction("Action", null).show()
-        }
+        
         val drawerLayout: DrawerLayout = findViewById(R.id.drawer_layout)
         val navView: NavigationView = findViewById(R.id.nav_view)
         val navController = findNavController(R.id.nav_host_fragment)

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -2,6 +2,7 @@ package com.soen390.conumap
 
 import android.os.Bundle
 import android.view.Menu
+import android.widget.Toast
 
 import com.google.android.material.navigation.NavigationView
 
@@ -15,6 +16,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 
 import com.soen390.conumap.helper.ContextPasser
+import com.soen390.conumap.map.Map
 import com.soen390.conumap.permission.Permission
 
 class MainActivity : AppCompatActivity() {
@@ -46,6 +48,17 @@ class MainActivity : AppCompatActivity() {
         // Inflate the menu; this adds items to the action bar if it is present.
         menuInflater.inflate(R.menu.main, menu)
         return true
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        // Makes sure locating circle is visible map moves to user location.
+        // This is primarily used when user exits app and toggles the app's location permission.
+        if(Map.mapLateinitsAreInitialized() && Permission.checkLocationPermission(this)) {
+            Map.getMapInstance().isMyLocationEnabled = true // Makes sure blue "I am here" dot shows.
+            Map.centerMapOnUserLocation(this)
+        }
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -1,10 +1,7 @@
 package com.soen390.conumap
 
-import android.content.pm.PackageManager
 import android.os.Bundle
-import android.view.Gravity
 import android.view.Menu
-import android.widget.Toast
 import com.google.android.material.navigation.NavigationView
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -16,7 +13,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.map.Map
-import com.soen390.conumap.map.Map.LOCATION_PERMISSION_REQUEST_CODE
 import com.soen390.conumap.permission.Permission
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -66,6 +66,8 @@ class MainActivity : AppCompatActivity() {
             LOCATION_PERMISSION_REQUEST_CODE -> {
                 if(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // User accepted the location permission.
+                    Map.getMapInstance().isMyLocationEnabled = true
+                    Map.centerMapOnUserLocation(this)
                 } else {
                     // User rejected the location permission.
                 }

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -41,7 +41,7 @@ class MainActivity : AppCompatActivity() {
         Map.setContext(this)
         BuildingCreator.setContext(this)
         Permission.setContext(this)
-        DeviceLocationChecker.setContext(this)
+        DeviceLocationChecker.setUp(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import com.soen390.conumap.building.BuildingCreator
+import com.soen390.conumap.helper.DeviceLocationChecker
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.permission.Permission
 
@@ -40,6 +41,7 @@ class MainActivity : AppCompatActivity() {
         Map.setContext(this)
         BuildingCreator.setContext(this)
         Permission.setContext(this)
+        DeviceLocationChecker.setContext(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -5,9 +5,6 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.Menu
 import android.widget.Toast
-import androidx.activity.viewModels
-import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.navigation.NavigationView
 import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
@@ -17,13 +14,7 @@ import androidx.navigation.ui.setupWithNavController
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.ViewModelProviders
-import com.soen390.conumap.Directions.directions
 import com.soen390.conumap.building.BuildingCreator
-import com.soen390.conumap.databinding.DirectionsFragmentBinding
-import com.soen390.conumap.ui.directions.DirectionsViewModel
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.map.Map.LOCATION_PERMISSION_REQUEST_CODE
 

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.soen390.conumap
 
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.Menu
 import androidx.activity.viewModels
@@ -21,6 +22,8 @@ import com.soen390.conumap.Directions.directions
 import com.soen390.conumap.databinding.DirectionsFragmentBinding
 import com.soen390.conumap.ui.directions.DirectionsViewModel
 import com.soen390.conumap.building.BuildingCreator.setContext
+import com.soen390.conumap.map.Map
+import com.soen390.conumap.map.Map.LOCATION_PERMISSION_REQUEST_CODE
 
 class MainActivity : AppCompatActivity() {
 
@@ -56,5 +59,18 @@ class MainActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         val navController = findNavController(R.id.nav_host_fragment)
         return navController.navigateUp(appBarConfiguration) || super.onSupportNavigateUp()
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        when(requestCode) {
+            LOCATION_PERMISSION_REQUEST_CODE -> {
+                if(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // User accepted the location permission.
+                } else {
+                    // User rejected the location permission.
+                }
+                return
+            }
+        }
     }
 }

--- a/app/src/main/java/com/soen390/conumap/MainActivity.kt
+++ b/app/src/main/java/com/soen390/conumap/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.appcompat.widget.Toolbar
 import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.map.Map.LOCATION_PERMISSION_REQUEST_CODE
+import com.soen390.conumap.permission.Permission
 
 class MainActivity : AppCompatActivity() {
 
@@ -42,6 +43,7 @@ class MainActivity : AppCompatActivity() {
         // Pass context to these files so they can access the resources.
         Map.setContext(this)
         BuildingCreator.setContext(this)
+        Permission.setContext(this)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -56,25 +58,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
-        when(requestCode) {
-            LOCATION_PERMISSION_REQUEST_CODE -> {
-                if(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    // User accepted the location permission.
-                    Map.getMapInstance().isMyLocationEnabled = true
-                    Map.centerMapOnUserLocation(this)
-                } else {
-                    // User rejected the location permission.
-                    val locationDeniedMessage: Toast = Toast.makeText(
-                        applicationContext,
-                        "Please allow location access to use all app features.",
-                        Toast.LENGTH_LONG
-                    )
-                    // Position the toast in the center so it is more likely to be seen by user.
-                    locationDeniedMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
-                    locationDeniedMessage.show()
-                }
-                return
-            }
-        }
+        Permission.handlePermissionResults(requestCode, permissions, grantResults, this)
     }
 }

--- a/app/src/main/java/com/soen390/conumap/building/BuildingsConstants.kt
+++ b/app/src/main/java/com/soen390/conumap/building/BuildingsConstants.kt
@@ -1,7 +1,0 @@
-package com.soen390.conumap.building
-
-import com.google.android.gms.maps.model.LatLng
-
-object BuildingsConstants {
-    val virus = LatLng(45.495506, -73.577774)
-}

--- a/app/src/main/java/com/soen390/conumap/campus/Campus.kt
+++ b/app/src/main/java/com/soen390/conumap/campus/Campus.kt
@@ -5,20 +5,21 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
 
-class Campus (var name: String, var location: LatLng, map: GoogleMap) {
+class Campus (var name: String, var info: String, var location: LatLng, map: GoogleMap) {
     var marker: Marker
 
     init {
-        this.marker = addBuildingMarker(map)
+        this.marker = addCampusMarker(map)
     }
 
     // Adds marker for this building to the map passed as an argument.
-    fun addBuildingMarker(map: GoogleMap): Marker {
+    fun addCampusMarker(map: GoogleMap): Marker {
         return map.addMarker(
             MarkerOptions()
                 .position(location)
                 .alpha(0.0F)
                 .title(name)
+                .snippet(info)
         )
     }
 }

--- a/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
@@ -12,9 +12,9 @@ object ContextPasser {
     fun setContexts(ctx: Context) {
         context = ctx
 
-        Map.setContext(ctx)
-        Permission.setContext(ctx)
-        BuildingCreator.setContext(ctx)
-        DeviceLocationChecker.setUp(ctx)
+        Map.setContext(context)
+        Permission.setContext(context)
+        BuildingCreator.setContext(context)
+        DeviceLocationChecker.setUp(context)
     }
 }

--- a/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
@@ -1,0 +1,18 @@
+package com.soen390.conumap.helper
+
+import android.content.Context
+import com.soen390.conumap.map.Map
+import com.soen390.conumap.permission.Permission
+
+object ContextPasser {
+    private lateinit var context: Context
+
+    // Context passed to ContextPasser and all other files that require context.
+    fun setContexts(ctx: Context) {
+        context = ctx
+
+        Map.setContext(ctx)
+        Permission.setContext(ctx)
+        DeviceLocationChecker.setUp(ctx)
+    }
+}

--- a/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/ContextPasser.kt
@@ -1,6 +1,7 @@
 package com.soen390.conumap.helper
 
 import android.content.Context
+import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.map.Map
 import com.soen390.conumap.permission.Permission
 
@@ -13,6 +14,7 @@ object ContextPasser {
 
         Map.setContext(ctx)
         Permission.setContext(ctx)
+        BuildingCreator.setContext(ctx)
         DeviceLocationChecker.setUp(ctx)
     }
 }

--- a/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
@@ -1,0 +1,23 @@
+package com.soen390.conumap.helper
+
+import android.content.Context
+import android.location.Location
+import android.location.LocationManager
+import android.os.Build
+import android.provider.Settings
+import androidx.annotation.RequiresApi
+
+// An object used to check if the location service on the device is enabled.
+object DeviceLocationChecker {
+    private lateinit var context: Context
+    fun setContext(ctx: Context) { context = ctx
+        locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+    }
+
+    lateinit var locationManager: LocationManager
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun isDeviceLocationEnabled(): Boolean {
+        return locationManager.isLocationEnabled()
+    }
+}

--- a/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
@@ -6,18 +6,21 @@ import android.location.LocationManager
 import android.os.Build
 import android.provider.Settings
 import androidx.annotation.RequiresApi
+import kotlin.properties.Delegates
 
 // An object used to check if the location service on the device is enabled.
 object DeviceLocationChecker {
     private lateinit var context: Context
     fun setContext(ctx: Context) { context = ctx
         locationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+        mode = Settings.Secure.getInt(context.contentResolver, Settings.Secure.LOCATION_MODE, Settings.Secure.LOCATION_MODE_OFF)
     }
 
+    var mode = -1
     lateinit var locationManager: LocationManager
 
     @RequiresApi(Build.VERSION_CODES.P)
-    fun isDeviceLocationEnabled(): Boolean {
-        return locationManager.isLocationEnabled()
+    fun isDeviceLocationEnabled(): Int {
+        return mode
     }
 }

--- a/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
+++ b/app/src/main/java/com/soen390/conumap/helper/DeviceLocationChecker.kt
@@ -1,12 +1,9 @@
 package com.soen390.conumap.helper
 
 import android.content.Context
-import android.location.Location
 import android.location.LocationManager
 import android.os.Build
 import android.provider.Settings
-import androidx.annotation.RequiresApi
-import kotlin.properties.Delegates
 
 // An object used to check if the location service on the device is enabled.
 object DeviceLocationChecker {

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -1,10 +1,8 @@
 package com.soen390.conumap.map
 
 import android.content.Context
-import android.os.Build
 import android.view.Gravity
 import android.widget.Toast
-import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -97,8 +95,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
             )
             locationDisabledMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
             locationDisabledMessage.show()
-        }
-        if(!Permission.checkLocationPermission(activity)) {
+        } else if(!Permission.checkLocationPermission(activity)) {
             // Show toast if user attempts to locate but location permission is denied.
             val locationDeniedMessage: Toast = Toast.makeText(
                 context,

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -72,7 +72,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
     }
 
     //This sets the UI settings for the map
-    private fun uiSettings(activity: FragmentActivity){
+    private fun uiSettings(activity: FragmentActivity) {
 
         // Hide toolbar to open destination in Google Maps externally.
         gMap.uiSettings.isMapToolbarEnabled = false
@@ -152,6 +152,14 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
             moveCamera(sgwCampus.location, 16f)
             sgwCampus.marker.showInfoWindow()
         }
+    }
+
+    // Can be used to determine if all lateinit fields were enabled to prevent app crash.
+    fun mapLateinitsAreInitialized(): Boolean {
+        return  ::gMap.isInitialized &&
+                ::loyolaCampus.isInitialized &&
+                ::sgwCampus.isInitialized &&
+                ::context.isInitialized
     }
 
     // Specifies behaviour when a clickable polygon is clicked.

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -122,11 +122,13 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
     private fun createCampuses() {
         loyolaCampus = Campus(
             "Loyola Campus",
+            "Notre-Dame-de-Grâce, QC",
             LatLng(45.458275, -73.640469),
             gMap
         )
         sgwCampus = Campus(
             "Sir George Williams Campus",
+            "Montreal, QC",
             LatLng(45.496061, -73.578467),
             gMap
         )

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -1,5 +1,9 @@
 package com.soen390.conumap.map
 
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -13,9 +17,9 @@ import com.soen390.conumap.building.BuildingInfoWindowAdapter
 import com.soen390.conumap.campus.Campus
 import com.soen390.conumap.permission.Permission
 
-object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener{
+object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener {
 
-    private const val LOCATION_PERMISSION_REQUEST_CODE = 1 //The constant for the permission code
+    const val LOCATION_PERMISSION_REQUEST_CODE = 1 //The constant for the permission code
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private var lastLocation: LatLng = LatLng(45.497304, -73.578923) //This is the last location of the user
     private lateinit var gMap: GoogleMap
@@ -33,16 +37,29 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
         gMap.setInfoWindowAdapter(BuildingInfoWindowAdapter(activity))
 
         //Checks the permissions and ask the user if the app does not have the permission to use the localisation feature
-        if(!Permission.checkPermission(activity)) {
-            Permission.requestPermission(activity, LOCATION_PERMISSION_REQUEST_CODE)
+//        if(!Permission.checkPermission(activity)) {
+//            Permission.requestPermission(activity, LOCATION_PERMISSION_REQUEST_CODE)
+//        }
+        if(ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED) {
+            // We don't have the location permission; request it.
+            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+            LOCATION_PERMISSION_REQUEST_CODE)
+            // After this happens, onRequestPermissionsResult is called automatically in MainActivity.
+        } else {
+            // Makes sure the mylocation is enabled
+            // We do this only when we are sure that the location permission has been allowed.
+            // Doing so before location granted will cause the app to crash.
+            gMap.isMyLocationEnabled = true
         }
 
         //Calls the uiSettings function to set the defaults for the map
         uiSettings(activity)
-        gMap.isMyLocationEnabled = true //Makes sure the mylocation  is enabled
+
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(activity) //Create the fusedLocation
         centerMapOnUserLocation(activity) //Center the map on the user
 
+        // Create all building objects, their corresponding markers, and their outlines.
         buildings = BuildingCreator.createBuildings(gMap)
 
        //Create the two campuses

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -35,11 +35,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
         gMap.setOnPolygonClickListener(this)
         gMap.setOnInfoWindowClickListener(this)
         gMap.setInfoWindowAdapter(BuildingInfoWindowAdapter(activity))
-
-        //Checks the permissions and ask the user if the app does not have the permission to use the localisation feature
-//        if(!Permission.checkPermission(activity)) {
-//            Permission.requestPermission(activity, LOCATION_PERMISSION_REQUEST_CODE)
-//        }
+        
         if(ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
             // We don't have the location permission; request it.

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -18,6 +18,7 @@ import com.soen390.conumap.building.Building
 import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.building.BuildingInfoWindowAdapter
 import com.soen390.conumap.campus.Campus
+import com.soen390.conumap.permission.Permission
 
 object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener {
 
@@ -42,11 +43,9 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
         gMap.setOnInfoWindowClickListener(this)
         gMap.setInfoWindowAdapter(BuildingInfoWindowAdapter(activity))
 
-        if(ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
-            != PackageManager.PERMISSION_GRANTED) {
+        if(!Permission.checkLocationPermission(activity)) {
             // We don't have the location permission; request it.
-            ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
-            LOCATION_PERMISSION_REQUEST_CODE)
+            Permission.requestLocationPermission(activity, LOCATION_PERMISSION_REQUEST_CODE)
             // After this happens, onRequestPermissionsResult is called automatically in MainActivity.
         } else {
             // We do this only when we are sure that the location permission has been allowed.
@@ -90,8 +89,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
 
     //This method centers the map on the user's current location
     fun centerMapOnUserLocation(activity: FragmentActivity) {
-        if(ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
-            != PackageManager.PERMISSION_GRANTED) {
+        if(!Permission.checkLocationPermission(activity)) {
             // Show toast if user attempts to locate but location permission is denied.
             val locationDeniedMessage: Toast = Toast.makeText(
                 context,

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -13,21 +13,19 @@ import com.google.android.gms.location.LocationServices
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.model.*
-import com.soen390.conumap.MainActivity
 import com.soen390.conumap.R
 import com.soen390.conumap.building.Building
 import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.building.BuildingInfoWindowAdapter
 import com.soen390.conumap.campus.Campus
-import com.soen390.conumap.permission.Permission
 
 object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener {
 
     const val LOCATION_PERMISSION_REQUEST_CODE = 1 //The constant for the permission code
-    private lateinit var fusedLocationClient: FusedLocationProviderClient
     private var lastLocation: LatLng = LatLng(45.497304, -73.578923) //This is the last location of the user
-    private lateinit var gMap: GoogleMap
     private var buildings: ArrayList<Building> = arrayListOf()
+    private lateinit var fusedLocationClient: FusedLocationProviderClient
+    private lateinit var gMap: GoogleMap
     private lateinit var loyolaCampus: Campus
     private lateinit var sgwCampus: Campus
     private lateinit var context: Context

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -97,6 +97,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
             locationDeniedMessage.show()
         } else {
             // Permission enabled, locate user.
+            fusedLocationClient = LocationServices.getFusedLocationProviderClient(activity)
             fusedLocationClient.lastLocation.addOnSuccessListener(activity) { location ->
                 // Got last known location. In some rare situations this can be null.
                 if (location != null) {

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -29,13 +29,13 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
 
     //This is function is called from MapFragment when the Map has loaded.
     //It sets all the default stuff for the map, like permission, centering on location, etc.
-    fun setUpMap(googleMap: GoogleMap, activity: FragmentActivity){
+    fun setUpMap(googleMap: GoogleMap, activity: FragmentActivity) {
 
         gMap = googleMap
         gMap.setOnPolygonClickListener(this)
         gMap.setOnInfoWindowClickListener(this)
         gMap.setInfoWindowAdapter(BuildingInfoWindowAdapter(activity))
-        
+
         if(ContextCompat.checkSelfPermission(activity, Manifest.permission.ACCESS_FINE_LOCATION)
             != PackageManager.PERMISSION_GRANTED) {
             // We don't have the location permission; request it.

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -1,12 +1,8 @@
 package com.soen390.conumap.map
 
-import android.Manifest
 import android.content.Context
-import android.content.pm.PackageManager
 import android.view.Gravity
 import android.widget.Toast
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -50,7 +46,7 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
         } else {
             // We do this only when we are sure that the location permission has been allowed.
             // Doing so before location granted will cause the app to crash.
-            gMap.isMyLocationEnabled = true // Makes sure the mylocation is enabled
+            gMap.isMyLocationEnabled = true // Makes sure the myLocation is enabled
             centerMapOnUserLocation(activity) // Center the map on the user
         }
 

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -1,8 +1,10 @@
 package com.soen390.conumap.map
 
 import android.content.Context
+import android.os.Build
 import android.view.Gravity
 import android.widget.Toast
+import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentActivity
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
@@ -14,6 +16,7 @@ import com.soen390.conumap.building.Building
 import com.soen390.conumap.building.BuildingCreator
 import com.soen390.conumap.building.BuildingInfoWindowAdapter
 import com.soen390.conumap.campus.Campus
+import com.soen390.conumap.helper.DeviceLocationChecker
 import com.soen390.conumap.permission.Permission
 
 object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, GoogleMap.OnInfoWindowClickListener {
@@ -84,7 +87,12 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
     }
 
     //This method centers the map on the user's current location
+    @RequiresApi(Build.VERSION_CODES.P)
     fun centerMapOnUserLocation(activity: FragmentActivity) {
+        var loc: Toast = Toast.makeText(context, "DeviceLocationChecker.isDeviceLocationEnabled is " +
+        DeviceLocationChecker.isDeviceLocationEnabled(), Toast.LENGTH_LONG)
+        loc.show()
+
         if(!Permission.checkLocationPermission(activity)) {
             // Show toast if user attempts to locate but location permission is denied.
             val locationDeniedMessage: Toast = Toast.makeText(
@@ -135,12 +143,11 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
     }
 
     //When the campuses button are clicked, this function is called. It determines which button has been clicked, and then move the camera to it.
-    fun focusOnCampus(campusSelected: String){
-        if(campusSelected.equals("Loyola")){
+    fun focusOnCampus(campusSelected: String) {
+        if(campusSelected.equals("Loyola")) {
             moveCamera(loyolaCampus.location, 16f)
             loyolaCampus.marker.showInfoWindow()
-        }
-        else{
+        } else {
             moveCamera(sgwCampus.location, 16f)
             sgwCampus.marker.showInfoWindow()
         }

--- a/app/src/main/java/com/soen390/conumap/map/Map.kt
+++ b/app/src/main/java/com/soen390/conumap/map/Map.kt
@@ -87,12 +87,17 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
     }
 
     //This method centers the map on the user's current location
-    @RequiresApi(Build.VERSION_CODES.P)
     fun centerMapOnUserLocation(activity: FragmentActivity) {
-        var loc: Toast = Toast.makeText(context, "DeviceLocationChecker.isDeviceLocationEnabled is " +
-        DeviceLocationChecker.isDeviceLocationEnabled(), Toast.LENGTH_LONG)
-        loc.show()
-
+        if(!DeviceLocationChecker.isDeviceLocationEnabled()) {
+            // Show toast if user attempts to locate but device location is turned off.
+            val locationDisabledMessage: Toast = Toast.makeText(
+                context,
+                "Can't locate because device location is turned off.",
+                Toast.LENGTH_LONG
+            )
+            locationDisabledMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
+            locationDisabledMessage.show()
+        }
         if(!Permission.checkLocationPermission(activity)) {
             // Show toast if user attempts to locate but location permission is denied.
             val locationDeniedMessage: Toast = Toast.makeText(
@@ -100,7 +105,6 @@ object Map: GoogleMap.OnPolygonClickListener, GoogleMap.OnMarkerClickListener, G
                 "Can't locate because location permission was denied.",
                 Toast.LENGTH_LONG
             )
-            // Position the toast in the center so it is more likely to be seen by user.
             locationDeniedMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
             locationDeniedMessage.show()
         } else {

--- a/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
+++ b/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
@@ -32,9 +32,6 @@ class MapFragment : Fragment() {
 
         //Call the Map setup method to set all the default stuff for the map
         Map.setUpMap(googleMap, activity!!)
-
-        //Added a marker to test the method
-        //Map.addMarker(LatLng(45.495418, -73.579169), "Bonjour")
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
+++ b/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
@@ -6,16 +6,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.navigation.fragment.NavHostFragment
-
-import com.google.android.gms.maps.CameraUpdateFactory
-import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
-import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.MarkerOptions
 import com.soen390.conumap.R
-import com.soen390.conumap.permission.Permission
 
 class MapFragment : Fragment() {
 

--- a/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
+++ b/app/src/main/java/com/soen390/conumap/map/MapFragment.kt
@@ -19,7 +19,6 @@ import com.soen390.conumap.permission.Permission
 
 class MapFragment : Fragment() {
 
-
     private val callback = OnMapReadyCallback { googleMap ->
         /**
          * Manipulates the map once available.
@@ -36,8 +35,6 @@ class MapFragment : Fragment() {
 
         //Added a marker to test the method
         //Map.addMarker(LatLng(45.495418, -73.579169), "Bonjour")
-
-
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/soen390/conumap/permission/Permission.kt
+++ b/app/src/main/java/com/soen390/conumap/permission/Permission.kt
@@ -1,18 +1,48 @@
 package com.soen390.conumap.permission
 
+import android.content.Context
 import androidx.core.app.ActivityCompat
 import android.content.pm.PackageManager
+import android.view.Gravity
+import android.widget.Toast
 import androidx.fragment.app.FragmentActivity
-import java.util.*
+import com.soen390.conumap.map.Map
 
 object Permission {
-    fun checkPermission(activity: FragmentActivity): Boolean {
+    private lateinit var context: Context
+
+    fun setContext(ctx: Context) { context = ctx }
+
+    fun checkLocationPermission(activity: FragmentActivity): Boolean {
         return ActivityCompat.checkSelfPermission(activity,
             android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
     }
 
-    fun requestPermission(activity: FragmentActivity, code: Int) {
+    fun requestLocationPermission(activity: FragmentActivity, code: Int) {
         ActivityCompat.requestPermissions(activity,
             arrayOf(android.Manifest.permission.ACCESS_FINE_LOCATION), code)
+    }
+
+    fun handlePermissionResults(requestCode: Int, permissions: Array<String>, grantResults: IntArray, activity: FragmentActivity) {
+        when(requestCode) {
+            Map.LOCATION_PERMISSION_REQUEST_CODE -> {
+                if(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                    // User accepted the location permission.
+                    Map.getMapInstance().isMyLocationEnabled = true
+                    Map.centerMapOnUserLocation(activity)
+                } else {
+                    // User rejected the location permission.
+                    val locationDeniedMessage: Toast = Toast.makeText(
+                        context,
+                        "Please allow location access to use all app features.",
+                        Toast.LENGTH_LONG
+                    )
+                    // Position the toast in the center so it is more likely to be seen by user.
+                    locationDeniedMessage.setGravity(Gravity.CENTER_VERTICAL, 0, 0)
+                    locationDeniedMessage.show()
+                }
+                return
+            }
+        }
     }
 }


### PR DESCRIPTION
Contains functionality to display a toast when a) the location permission of the **application** was denied, or b) the **device** location is disabled. 

Please check the following:

a) Location permission message
1) Uninstall the app or remove location permission from the app
2) Reinstall/open the app again, you should see the prompt to let ConUMap access your location (this is what happens on phone, I'm not sure what it's like for the emulator)

* If you press Deny, a message should appear saying "Can't locate because location permission was denied."
* If after denying, you attempt to press the "locate user" button, the same message should appear
* If you press Allow, it should immediately focus the map on your location (it didn't used to do this immediately after accepting permission! Used to only do it on app open AFTER permission was already accepted)

b) Device location message -- you can test this with the location permission already accepted
1) Turn off device location
2) Open application
* If you open the app with location of device turned off, a message should say "Can't locate because device location is turned off." and it will not move the map.
* If you attempt to press the "locate user" button, and device location is disabled, the same message should appear

For b), would be great if we could have approval from phone and emulator. The way of checking if device location is on is different for different versions of Android, so if we could check that it works on both >API 23 (newer than Marshmallow) and <=API 23 (Marshmallow and older), would be great. In addition, feel free to try toggling the device location while the app is open to see if it works. 